### PR TITLE
Utilize IS_NEW_LOGIC flag when checking if account needs to be upgraded

### DIFF
--- a/upgrade-accounts.py
+++ b/upgrade-accounts.py
@@ -36,12 +36,13 @@ def main():
     accounts = []
     account_query = chain.query_map('System', 'Account', page_size=1000)
 
+    NEW_LOGIC_FLAG = 0x80000000_00000000_00000000_00000000
+
     for (i, (id, info)) in enumerate(account_query):
         account = info['data']
-        frozen = account['frozen']
-        reserved = account['reserved']
+        flags = account['flags'].decode()
 
-        if reserved > 0 or frozen > 0:
+        if flags & NEW_LOGIC_FLAG == 0:
             accounts.append(id.value)
 
         if i % 5000 == 0 and i > 0:


### PR DESCRIPTION
In the `pallet-balances` (https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/balances/src/types.rs#L111), a check whether an account needs to be upgraded or not is done via a flag check.

Perhaps the same should be done in the script as well?
Or is the approach with `free/reserved` check taken because accounts aren't impacted if these values are zero?