### PR TITLE
fix: only include outdated accounts in upgrade-accounts.py

### DIFF
--- a/upgrade-accounts.py
+++ b/upgrade-accounts.py
@@ -40,8 +40,9 @@ def main():
         account = info['data']
         frozen = account['frozen']
         reserved = account['reserved']
+        flags = account['flags'].decode()
 
-        if reserved > 0 or frozen > 0:
+        if (reserved > 0 or frozen > 0) and flags == 0:
             accounts.append(id.value)
 
         if i % 5000 == 0 and i > 0:

--- a/upgrade-accounts.py
+++ b/upgrade-accounts.py
@@ -40,7 +40,7 @@ def main():
         account = info['data']
         frozen = account['frozen']
         reserved = account['reserved']
-        flags = account['flags'].decode()
+        flags = account['flags']
 
         if (reserved > 0 or frozen > 0) and flags == 0:
             accounts.append(id.value)


### PR DESCRIPTION
Successor of #1 because the current script does not distinguish between accounts which have been upgraded and those waiting for upgrade. The conditional of `frozen` or `reserved` being non-zero is insufficient. We need to additionally check whether the `flags` key has been set. 

I am not a python expert, so I left this check with `flags == 0`. Most ideally, it would check whether `flags !=  0x80000000_00000000_00000000_00000000` but for some reason this also included accounts with flags set to exactly that value.